### PR TITLE
Allow Custom Instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 Firefox extension to easily switch between Piped and Youtube.
 
 * Context menu.
+* Allows for different instances.

--- a/addon/html/options.html
+++ b/addon/html/options.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <title>Piped Switch Options</title>
@@ -33,7 +33,7 @@
     Open in new tab: <input type="checkbox" id="newTabCheckbox"/>
 </label>
 <label>
-    Instance URL: <input type="url" placeholder="https://piped.kavin.rocks/" id="instanceUrlInput"/>
+    Piped Instance URL: <input type="url" placeholder="https://piped.kavin.rocks/" id="instanceUrlInput"/>
 </label>
 <script src="../js/options.js"></script>
 </body>

--- a/addon/html/options.html
+++ b/addon/html/options.html
@@ -33,8 +33,11 @@
     Open in new tab: <input type="checkbox" id="newTabCheckbox"/>
 </label>
 <label>
-    Piped URL: <input type="url" placeholder="https://piped.kavin.rocks/" id="instanceUrlInput"/>
-    (requires reload)
+    Piped instance URL: <input type="url" placeholder="https://piped.kavin.rocks/" id="instanceUrlInput"/>
+    <br>
+    &emsp;<i>Instances:</i>
+    <a href="https://github.com/TeamPiped/Piped#mirrors">#1</a>
+    <a href="https://github.com/TeamPiped/Piped/wiki/Instances">#2</a>    
 </label>
 <script src="../js/options.js"></script>
 </body>

--- a/addon/html/options.html
+++ b/addon/html/options.html
@@ -2,37 +2,40 @@
 <html>
 
 <head>
-  <title>Piped Switch Options</title>
+    <title>Piped Switch Options</title>
 </head>
 <style>
     body {
-      font-family: 'Arial', sans-serif;
-      background-color: #f4f4f4;
-      margin: 20px;
-      text-align: center;
+        font-family: 'Arial', sans-serif;
+        background-color: #f4f4f4;
+        margin: 20px;
+        text-align: center;
     }
 
     h1 {
-      color: #333;
+        color: #333;
     }
 
     label {
-      display: block;
-      margin-top: 20px;
-      font-size: 18px;
+        display: block;
+        margin-top: 20px;
+        font-size: 18px;
     }
 
     input[type="checkbox"] {
-      margin-right: 10px;
-      transform: scale(1.5);
+        margin-right: 10px;
+        transform: scale(1.5);
     }
-  </style>
+</style>
 <body>
-  <h1>Options</h1>
-  <label>
-    <input type="checkbox" id="newTabCheckbox"> Open in new tab
-  </label>
-  <script src="../js/options.js"></script>
+<h1>Options</h1>
+<label>
+    Open in new tab: <input type="checkbox" id="newTabCheckbox"/>
+</label>
+<label>
+    Instance URL: <input type="url" placeholder="https://piped.kavin.rocks/" id="instanceUrlInput"/>
+</label>
+<script src="../js/options.js"></script>
 </body>
 
 </html>

--- a/addon/html/options.html
+++ b/addon/html/options.html
@@ -33,7 +33,8 @@
     Open in new tab: <input type="checkbox" id="newTabCheckbox"/>
 </label>
 <label>
-    Piped Instance URL: <input type="url" placeholder="https://piped.kavin.rocks/" id="instanceUrlInput"/>
+    Piped URL: <input type="url" placeholder="https://piped.kavin.rocks/" id="instanceUrlInput"/>
+    (requires reload)
 </label>
 <script src="../js/options.js"></script>
 </body>

--- a/addon/js/background.js
+++ b/addon/js/background.js
@@ -2,16 +2,14 @@ const YOUTUBE_URL = "https://www.youtube.com/";
 
 browser.storage.sync.get('instanceUrl', function (result) {
     let pipedUrl = result.instanceUrl || 'https://piped.kavin.rocks/';
+
     window.browser.contextMenus.create({
         "title": "Piped Switch",
         "onclick": Switch,
         "documentUrlPatterns": ['*://*.youtube.com/*', pipedUrl + '*']
     });
-});
 
-function Switch(info) {
-    browser.storage.sync.get('instanceUrl', function (result) {
-        let pipedUrl = result.instanceUrl || 'https://piped.kavin.rocks/';
+    function Switch(info) {
         const CURRENT_URL = info.pageUrl;
         let newUrl = CURRENT_URL;
 
@@ -29,5 +27,5 @@ function Switch(info) {
                 browser.tabs.update({url: newUrl});
             }
         });
-    });
-}
+    }
+});

--- a/addon/js/background.js
+++ b/addon/js/background.js
@@ -20,9 +20,9 @@ function Switch(info) {
     browser.storage.sync.get('openInNewTab', function (result) {
         const openInNewTab = result.openInNewTab || false;
         if (openInNewTab) {
-            browser.tabs.create({ url: newUrl });
+            browser.tabs.create({url: newUrl});
         } else {
-            browser.tabs.update({ url: newUrl });
+            browser.tabs.update({url: newUrl});
         }
     });
 }

--- a/addon/js/background.js
+++ b/addon/js/background.js
@@ -1,28 +1,33 @@
 const YOUTUBE_URL = "https://www.youtube.com/";
-const PIPED_URL = "https://piped.kavin.rocks/";
 
-window.browser.contextMenus.create({
-    "title": "Piped Switch",
-    "onclick": Switch,
-    "documentUrlPatterns": ['*://*.youtube.com/*', '*://piped.kavin.rocks/*']
-})
+browser.storage.sync.get('instanceUrl', function (result) {
+    let pipedUrl = result.instanceUrl || 'https://piped.kavin.rocks/';
+    window.browser.contextMenus.create({
+        "title": "Piped Switch",
+        "onclick": Switch,
+        "documentUrlPatterns": ['*://*.youtube.com/*', pipedUrl + '*']
+    });
+});
 
 function Switch(info) {
-    const CURRENT_URL = info.pageUrl;
-    let newUrl = CURRENT_URL;
+    browser.storage.sync.get('instanceUrl', function (result) {
+        let pipedUrl = result.instanceUrl || 'https://piped.kavin.rocks/';
+        const CURRENT_URL = info.pageUrl;
+        let newUrl = CURRENT_URL;
 
-    if (CURRENT_URL.includes(YOUTUBE_URL)) {
-        newUrl = PIPED_URL + CURRENT_URL.split(YOUTUBE_URL)[1];
-    } else if (CURRENT_URL.includes(PIPED_URL)) {
-        newUrl = YOUTUBE_URL + CURRENT_URL.split(PIPED_URL)[1];
-    }
-
-    browser.storage.sync.get('openInNewTab', function (result) {
-        const openInNewTab = result.openInNewTab || false;
-        if (openInNewTab) {
-            browser.tabs.create({url: newUrl});
-        } else {
-            browser.tabs.update({url: newUrl});
+        if (CURRENT_URL.includes(YOUTUBE_URL)) {
+            newUrl = pipedUrl + CURRENT_URL.split(YOUTUBE_URL)[1];
+        } else if (CURRENT_URL.includes(pipedUrl)) {
+            newUrl = YOUTUBE_URL + CURRENT_URL.split(pipedUrl)[1];
         }
+
+        browser.storage.sync.get('openInNewTab', function (result) {
+            const openInNewTab = result.openInNewTab || false;
+            if (openInNewTab) {
+                browser.tabs.create({url: newUrl});
+            } else {
+                browser.tabs.update({url: newUrl});
+            }
+        });
     });
 }

--- a/addon/js/background.js
+++ b/addon/js/background.js
@@ -1,7 +1,11 @@
 const YOUTUBE_URL = "https://www.youtube.com/";
+const DEFAULT_PIPED_INSTANCE_URL = "https://piped.kavin.rocks/";
+
+let pipedUrl = DEFAULT_PIPED_INSTANCE_URL;
 
 browser.storage.sync.get('instanceUrl', function (result) {
-    let pipedUrl = result.instanceUrl || 'https://piped.kavin.rocks/';
+
+    pipedUrl = result.instanceUrl || DEFAULT_PIPED_INSTANCE_URL;
 
     window.browser.contextMenus.create({
         "title": "Piped Switch",
@@ -27,5 +31,12 @@ browser.storage.sync.get('instanceUrl', function (result) {
                 browser.tabs.update({url: newUrl});
             }
         });
+    }
+});
+
+
+browser.storage.onChanged.addListener(function (changes, area) {
+    if (area === 'sync' && changes.instanceUrl) {
+        pipedUrl = changes.instanceUrl.newValue || DEFAULT_PIPED_INSTANCE_URL;
     }
 });

--- a/addon/js/options.js
+++ b/addon/js/options.js
@@ -12,6 +12,6 @@ document.addEventListener('DOMContentLoaded', function () {
         document.getElementById('instanceUrlInput').value = result.instanceUrl || 'https://piped.kavin.rocks/';
     });
     document.getElementById('instanceUrlInput').addEventListener('change', function () {
-        browser.storage.sync.set({'instanceUrl': this.value});
+        browser.storage.sync.set({'instanceUrl': this.value.slice(-1) === '/' ? this.value : this.value + '/'});
     });
 });

--- a/addon/js/options.js
+++ b/addon/js/options.js
@@ -1,9 +1,17 @@
 document.addEventListener('DOMContentLoaded', function () {
+    // Open in new tab
     browser.storage.sync.get('openInNewTab', function (result) {
-      document.getElementById('newTabCheckbox').checked = result.openInNewTab || false;
+        document.getElementById('newTabCheckbox').checked = result.openInNewTab || false;
     });
-  
     document.getElementById('newTabCheckbox').addEventListener('change', function () {
-      browser.storage.sync.set({ 'openInNewTab': this.checked });
+        browser.storage.sync.set({'openInNewTab': this.checked});
     });
-  });
+
+    // Use custom instance URL
+    browser.storage.sync.get('instanceUrl', function (result) {
+        document.getElementById('instanceUrlInput').value = result.instanceUrl || 'https://piped.kavin.rocks/';
+    });
+    document.getElementById('instanceUrlInput').addEventListener('change', function () {
+        browser.storage.sync.set({'instanceUrl': this.value});
+    });
+});

--- a/addon/js/options.js
+++ b/addon/js/options.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', function () {
     browser.storage.sync.get('instanceUrl', function (result) {
         document.getElementById('instanceUrlInput').value = result.instanceUrl || 'https://piped.kavin.rocks/';
     });
-    document.getElementById('instanceUrlInput').addEventListener('change', function () {
+    document.getElementById('instanceUrlInput').addEventListener('input', function () {
         browser.storage.sync.set({'instanceUrl': this.value});
     });
 });

--- a/addon/js/options.js
+++ b/addon/js/options.js
@@ -12,6 +12,6 @@ document.addEventListener('DOMContentLoaded', function () {
         document.getElementById('instanceUrlInput').value = result.instanceUrl || 'https://piped.kavin.rocks/';
     });
     document.getElementById('instanceUrlInput').addEventListener('change', function () {
-        browser.storage.sync.set({'instanceUrl': this.value.slice(-1) === '/' ? this.value : this.value + '/'});
+        browser.storage.sync.set({'instanceUrl': this.value});
     });
 });

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Piped Switch",
-  "version": "1.2.0",
+  "version": "1.1.0",
   "description": "A context menu button to easily switch between Piped and Youtube.",
   "permissions": [
     "contextMenus",

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Piped Switch",
   "version": "1.1.0",
-  "description": "A context menu button to easily switch between Piped and Youtube.",
+  "description": "A context menu button to easily switch between Piped and YouTube.",
   "permissions": [
     "contextMenus",
     "storage",

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Piped Switch",
-  "version": "1.0.2",
+  "version": "1.2.0",
   "description": "A context menu button to easily switch between Piped and Youtube.",
   "permissions": [
     "contextMenus",


### PR DESCRIPTION
Allows users to set a custom instance in settings as requested in #1.

If the user doesn't set an instance, or clears the URL in settings, the addon defaults to https://piped.kavin.rocks/.